### PR TITLE
Allow the user to set custom fuzzy identifiers which the variables map to

### DIFF
--- a/src/main/antlr/edu/illinois/cs/cs125/fuzzyjava/antlr/fuzzyjava/FuzzyJavaParser.g4
+++ b/src/main/antlr/edu/illinois/cs/cs125/fuzzyjava/antlr/fuzzyjava/FuzzyJavaParser.g4
@@ -388,6 +388,7 @@ statement
     : blockLabel=block
     | ASSERT expression (':' expression)? semicolon
     | IF parExpression statement (ELSE statement)?
+    | fuzzyIfElse
     | FOR '(' forControl ')' statement
     | WHILE parExpression statement
     | DO statement WHILE parExpression semicolon
@@ -632,4 +633,8 @@ identifier
 
 semicolon
     : SEMI
+    ;
+
+fuzzyIfElse
+    : QUESTION IF parExpression statement (ELSE statement)? QUESTION
     ;

--- a/src/main/kotlin/edu/illinois/cs/cs125/fuzzyjava/Listeners.kt
+++ b/src/main/kotlin/edu/illinois/cs/cs125/fuzzyjava/Listeners.kt
@@ -241,6 +241,7 @@ class Fuzzer(private val configuration: FuzzConfiguration) : FuzzyJavaParserBase
     override fun enterSemicolon(ctx: FuzzyJavaParser.SemicolonContext) {
         val removeSemicolonsTransformation = configuration.fuzzyTransformations?.find { it.name == "remove-semicolons" }
         if (removeSemicolonsTransformation != null) {
+            val matchLength = ctx.stop.charPositionInLine + 1
             // Check that semicolon transformation is requested by the user
             if (removeSemicolonsTransformation.arguments.contains("all") || Math.random() > 0.5) {
                 // If all semicolons are to be removed OR if semicolons are removed randomly and
@@ -248,7 +249,7 @@ class Fuzzer(private val configuration: FuzzConfiguration) : FuzzyJavaParserBase
                 sourceModifications.add(lazy {
                     SourceModification(
                             ctx.text, ctx.start.line, ctx.start.charPositionInLine,
-                            ctx.start.line, ctx.start.charPositionInLine, ctx.text, " ")
+                            ctx.start.line, matchLength, ";", " ")
                 })
             }
         }

--- a/src/test/kotlin/edu/illinois/cs/cs125/fuzzyjava/TestFuzz.kt
+++ b/src/test/kotlin/edu/illinois/cs/cs125/fuzzyjava/TestFuzz.kt
@@ -23,6 +23,8 @@ class TestFuzz : StringSpec({
     val unit2 = File("/Users/arjunvnair/IdeaProjects/fuzzyjava/src/test/resources/unit2.txt").readText().trim()
     val unit3 = File("/Users/arjunvnair/IdeaProjects/fuzzyjava/src/test/resources/unit3.txt").readText().trim()
 
+    // Core Fuzzing - Comparisons, Identifiers, Literals
+
     "should not modify blocks without fuzz" {
         val source = block
         val fuzzedSource = fuzzBlock(source)
@@ -68,33 +70,36 @@ class TestFuzz : StringSpec({
         val source = unit2
         val fuzzedSource = fuzzCompilationUnit(source)
         fuzzedSource shouldNotBe source
-        //println(fuzzedSource)
     }
+
     "should implement fuzzy class identifies on compilation units" {
         val source = unit3
         val fuzzedSource = fuzzCompilationUnit(source)
         fuzzedSource shouldNotBe source
-        //println(fuzzedSource)
     }
+
     "should implement fuzzy literals" {
         val source = block2
         val fuzzedSource = fuzzBlock(source)
         fuzzedSource shouldContain "int x = [0-9]+;".toRegex()
         fuzzedSource shouldContain "double y = [0-9]+\\.[0-9]+;".toRegex()
     }
+
+    // Documentation
+
     "should generate documentation" {
         val source = block3
         val fuzzedSource = fuzzBlock(source)
         fuzzedSource shouldNotBe source
     }
 
+    // AST Transformations
 
     "should remove semicolons if [remove-semicolons all] transformation is applied" {
         val source = unit1
         val fuzzConfiguration = FuzzConfiguration()
         fuzzConfiguration.fuzzyTransformations?.add(RemoveSemicolons(false))
         val fuzzedSource = fuzzCompilationUnitWithoutParse(source, fuzzConfiguration)
-
         fuzzedSource shouldNotContain(";")
     }
 })


### PR DESCRIPTION
This allows the user to optionally use custom identifiers (ex. "fizz" or "buzz" to fuzz the variables to) rather than cs125Id_; however, it still defaults to a infinitely generated sequence of cs125Id_s when a) the user does not specify custom identifiers or b) custom identifiers have run out (there are more defined identifiers in the original source code than there are specified custom identifiers).